### PR TITLE
Add Git Workflow Standards and fix ZAP action reference

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,3 +9,14 @@
 - Avoid apologizing or making conciliatory statements.
 - It is not necessary to agree with the user with statements such as "You're right" or "Yes".
 - Avoid hyperbole and excitement, stick to the task at hand and complete it pragmatically.
+
+## Git Workflow Standards
+
+- Every code change MUST have an associated GitHub issue created before starting work.
+- Use feature branches for all development work. Branch naming convention: `feature/<issue-number>-<short-description>` (e.g., `feature/42-add-login-page`).
+- Feature branches MUST be created off of the `main` branch.
+- All commits MUST reference the associated GitHub issue using keywords (e.g., `Fixes #42`, `Closes #42`, `Relates to #42`).
+- Push feature branches to the remote repository regularly to enable collaboration and backup.
+- Create a pull request (PR) to merge the feature branch back into `main` once the work is complete.
+- PRs MUST reference the associated GitHub issue in the description.
+- Delete feature branches after they have been merged into `main`.

--- a/.github/workflows/DAST-ZAP-Zed-Attach-Proxy-Checkmarx.yml
+++ b/.github/workflows/DAST-ZAP-Zed-Attach-Proxy-Checkmarx.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Show results
         run: |
           ls 
-      - uses: githubabcs-devops/zap-to-ghas@main
+      - uses: devopsabcs-engineering/zap-to-ghas@main
       
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Fixes #6

- Add Git Workflow Standards section to copilot-instructions.md
- Fix zap-to-ghas action reference to use devopsabcs-engineering org